### PR TITLE
Move ManagePackageVersionsCentrally property to Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,6 +19,10 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
+  <!-- Package Management -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
   <!-- Package Commons -->
   <ItemGroup>
     <PackageReference Include="Escendit.Tools.Branding">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,4 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0"/>
     <PackageVersion Include="Aspire.Hosting" Version="9.4.0"/>


### PR DESCRIPTION
Closes #35 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized NuGet package version management is now enabled for the solution. This change does not affect application features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->