### PR TITLE
Update package versions and add restore lock file settings in Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,10 +12,10 @@
     <RepositoryUrl>https://github.com/escendit/dotnet-template</RepositoryUrl>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
-  <!-- NuGet Restore: Cache -->
+  <!-- NuGet Restore -->
   <PropertyGroup>
-    <RestoreLockedMode>true</RestoreLockedMode>
-    <RestorePackagesWithLockFile Condition="'$(CI)' == 'true'">true</RestorePackagesWithLockFile>
+    <RestoreLockedMode Condition="'$(CI)' == 'true'">true</RestoreLockedMode>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
   <!-- Packaging -->
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,11 @@
     <RepositoryUrl>https://github.com/escendit/dotnet-template</RepositoryUrl>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
+  <!-- NuGet Restore: Cache -->
+  <PropertyGroup>
+    <RestoreLockedMode>true</RestoreLockedMode>
+    <RestorePackagesWithLockFile Condition="'$(CI)' == 'true'">true</RestorePackagesWithLockFile>
+  </PropertyGroup>
   <!-- Packaging -->
   <PropertyGroup>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,11 +12,10 @@
     <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.0"/>
     <PackageVersion Include="coverlet.collector" Version="6.0.4"/>
     <PackageVersion Include="Dapper" Version="2.1.66"/>
-    <PackageVersion Include="Escendit.Tools.Branding" Version="1.0.3-rc.3"/>
-    <PackageVersion Include="Escendit.Tools.CodeAnalysis.NetAnalyzers" Version="0.5.1-rc.4"/>
-    <PackageVersion Include="Escendit.Tools.CodeAnalysis.StyleCopAnalyzers" Version="0.5.1-rc.5"/>
-    <PackageVersion Include="Escendit.Tools.CodeAnalysis.xUnitAnalyzers" Version="0.1.0-rc.21"/>
-    <PackageVersion Include="Escendit.Tools.CodeAnalysis.NSubstituteAnalyzers" Version="0.1.0-rc.18"/>
+    <PackageVersion Include="Escendit.Tools.Branding" Version="1.2.0"/>
+    <PackageVersion Include="Escendit.Tools.CodeAnalysis.NetAnalyzers" Version="0.6.0"/>
+    <PackageVersion Include="Escendit.Tools.CodeAnalysis.StyleCopAnalyzers" Version="0.6.0"/>
+    <PackageVersion Include="Escendit.Tools.CodeAnalysis.xUnitAnalyzers" Version="0.1.0"/>
     <PackageVersion Include="FluentMigrator" Version="7.1.0"/>
     <PackageVersion Include="FluentMigrator.Extensions.Postgres" Version="7.1.0"/>
     <PackageVersion Include="FluentMigrator.Runner" Version="7.1.0"/>


### PR DESCRIPTION
Closes #38 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package versions for several Escendit.Tools components.
  * Removed the Escendit.Tools.CodeAnalysis.NSubstituteAnalyzers package.
  * Enhanced build configuration to enforce locked package restore and enable lock file usage during continuous integration builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->